### PR TITLE
ci(development): update workflow path filters for detecting changes

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -36,7 +36,6 @@ jobs:
             - 'composer.json'
             - 'src/**'
             - 'tests/**'
-            - 'composer.*'
             - 'phpunit.xml'
             - 'phpstan.neon'
           rust:
@@ -45,7 +44,6 @@ jobs:
             - 'Cargo.lock'
             - 'rust-toolchain.toml'
             - 'crates/**'
-            - 'bin/build.sh'
 
   check-php-quality:
     name: Check PHP Code Quality


### PR DESCRIPTION
Updated the paths filter configuration to make sure only relevant file changes trigger certain jobs. Removed `composer.*` because changes to the `composer.json` file is explicitly covered by `composer.json` (and we aren't tracking `composer.lock` in git). Removed `bin/build.sh` to prevent unnecessary builds because changes to this file don't necessarily mean Rust code has changed (as discussed in PR #4).