### PR TITLE
ci(development): remove environment from PHP test job

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -251,7 +251,6 @@ jobs:
       (needs.find-native-libraries.result == 'success' || needs.find-native-libraries.result == 'skipped') &&
       (needs.build-native-libraries.result == 'success' || needs.build-native-libraries.result == 'skipped')
     runs-on: ${{ matrix.os }}
-    environment: development
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Remove the environment key from the PHP test job to avoid unnecessary deployment messages in pull requests. Repository-level secrets are now used instead of environment-level secrets.