### PR TITLE
feat(rust): add `dt` parameter to encryption response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "strum",
  "thiserror 2.0.12",
  "tokio",
 ]
@@ -2558,6 +2559,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "subtle"

--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ For columns configured with the `unique`, `ore`, and/or `match` indexes:
 {
     "k": "ct",
     "c": "mBbM8rvts7^sycKCI!-Y9x2kL8vN...",
+    "dt": "text",
     "hm": "0f4f3b99671e74c0f8b5a1d2e3f4...",
     "ob": null,
     "bf": null,
@@ -510,6 +511,7 @@ Response parameters:
 |-----------|-----------|--------|-------------|
 | `k` | `string` | Always | Key type identifier (always `ct` for ciphertext) |
 | `c` | `string` | Always | Base85-encoded ciphertext containing the encrypted data |
+| `dt` | `string` | Always | Data type for casting (from `cast_as` configuration parameter) |
 | `hm` | `string\|null` | `unique` | HMAC index for exact equality queries and uniqueness constraints |
 | `ob` | `array\|null` | `ore` | Order-revealing encryption index for range queries |
 | `bf` | `array\|null` | `match` | Bloom filter index for full-text search queries |
@@ -524,6 +526,7 @@ For columns configured with the `ste_vec` index:
 {
     "k": "sv",
     "c": "mBbKND$(wyS}0*#KjqS!Is$dX...",
+    "dt": "jsonb",
     "sv": [
         {
             "tokenized_selector": "dd4659b9c279af040dd05ce21b2a22f7",
@@ -546,6 +549,7 @@ Response parameters:
 |-----------|------|--------|-------------|
 | `k` | `string` | Always | Key type identifier (always `sv` for structured vector) |
 | `c` | `string` | Always | Base85-encoded ciphertext containing the encrypted data |
+| `dt` | `string` | Always | Data type for casting (from `cast_as` configuration parameter) |
 | `sv` | `array` | `ste_vec` | Structured text encryption vector for JSONB containment queries |
 | `sv[].tokenized_selector` | `string` | `ste_vec` | Encrypted selector for the JSON path |
 | `sv[].term` | `string` | `ste_vec` | Encrypted term value |

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -17,5 +17,6 @@ libc = "0.2"
 once_cell = { version = "1.21.3", default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.140", default-features = false }
+strum = { version = "0.27.1", default-features = false, features = ["derive"] }
 thiserror = "2.0.8"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -633,34 +633,25 @@ async fn encrypt_bulk_inner(
         },
     );
 
-    for (i, plaintext_target) in plaintext_targets.into_iter().enumerate() {
-        pipeline.add_with_ref::<PlaintextTarget>(plaintext_target, i)?;
+    for (index, plaintext_target) in plaintext_targets.into_iter().enumerate() {
+        pipeline.add_with_ref::<PlaintextTarget>(plaintext_target, index)?;
     }
 
     let mut source_encrypted = pipeline.encrypt(service_token).await?;
 
     let mut results: Vec<Encrypted> = Vec::with_capacity(len);
 
-    for i in 0..len {
-        let encrypted = source_encrypted.remove(i).ok_or_else(|| {
+    for index in 0..len {
+        let encrypted = source_encrypted.remove(index).ok_or_else(|| {
             Error::InvariantViolation(format!(
-                "`encrypt_bulk` expected a result in the pipeline at index {i}, but there was none"
+                "`encrypt_bulk` expected a result in the pipeline at index {index}, but there was none"
             ))
         })?;
 
-        let ident = identifiers.get(i).ok_or_else(|| {
-            Error::InvariantViolation(format!(
-                "`encrypt_bulk` expected an identifier to exist for index {i}, but there was none"
-            ))
-        })?;
+        let identifier = &identifiers[index];
+        let cast_as = &cast_types[index];
 
-        let cast_as = cast_types.get(i).ok_or_else(|| {
-            Error::InvariantViolation(format!(
-                "`encrypt_bulk` expected a cast_as to exist for index {i}, but there was none"
-            ))
-        })?;
-
-        let eql_payload = to_eql_encrypted(encrypted, ident, cast_as)?;
+        let eql_payload = to_eql_encrypted(encrypted, identifier, cast_as)?;
 
         results.push(eql_payload);
     }

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -107,6 +107,8 @@ class ClientTest extends TestCase
             $this->assertArrayHasKey('c', $result);
             $this->assertIsString($result['c']);
             $this->assertNotEmpty($result['c']);
+            $this->assertArrayHasKey('dt', $result);
+            $this->assertEquals('text', $result['dt']);
             $this->assertArrayHasKey('i', $result);
             $identifier = $result['i'];
             $this->assertIsArray($identifier);
@@ -247,6 +249,8 @@ class ClientTest extends TestCase
             $this->assertArrayHasKey('c', $result);
             $this->assertIsString($result['c']);
             $this->assertNotEmpty($result['c']);
+            $this->assertArrayHasKey('dt', $result);
+            $this->assertEquals('jsonb', $result['dt']);
             $this->assertArrayHasKey('sv', $result);
             $this->assertIsArray($result['sv']);
             $this->assertNotEmpty($result['sv']);
@@ -419,6 +423,8 @@ class ClientTest extends TestCase
             $ciphertext = $result['c'];
             $this->assertIsString($ciphertext);
             $this->assertNotEmpty($ciphertext);
+            $this->assertArrayHasKey('dt', $result);
+            $this->assertEquals('text', $result['dt']);
 
             $decrypted = $client->decrypt($clientPtr, $ciphertext, $contextJson);
             $this->assertEquals($plaintext, $decrypted);
@@ -588,6 +594,8 @@ class ClientTest extends TestCase
             $this->assertArrayHasKey('c', $emailResult);
             $this->assertIsString($emailResult['c']);
             $this->assertNotEmpty($emailResult['c']);
+            $this->assertArrayHasKey('dt', $emailResult);
+            $this->assertEquals('text', $emailResult['dt']);
             $this->assertArrayHasKey('i', $emailResult);
             $emailIdentifier = $emailResult['i'];
             $this->assertIsArray($emailIdentifier);
@@ -601,6 +609,8 @@ class ClientTest extends TestCase
             $this->assertArrayHasKey('c', $ageResult);
             $this->assertIsString($ageResult['c']);
             $this->assertNotEmpty($ageResult['c']);
+            $this->assertArrayHasKey('dt', $ageResult);
+            $this->assertEquals('int', $ageResult['dt']);
             $this->assertArrayHasKey('i', $ageResult);
             $ageIdentifier = $ageResult['i'];
             $this->assertIsArray($ageIdentifier);
@@ -614,6 +624,8 @@ class ClientTest extends TestCase
             $this->assertArrayHasKey('c', $jobTitleResult);
             $this->assertIsString($jobTitleResult['c']);
             $this->assertNotEmpty($jobTitleResult['c']);
+            $this->assertArrayHasKey('dt', $jobTitleResult);
+            $this->assertEquals('text', $jobTitleResult['dt']);
             $this->assertArrayHasKey('i', $jobTitleResult);
             $jobTitleIdentifier = $jobTitleResult['i'];
             $this->assertIsArray($jobTitleIdentifier);
@@ -627,6 +639,8 @@ class ClientTest extends TestCase
             $this->assertArrayHasKey('c', $metadataResult);
             $this->assertIsString($metadataResult['c']);
             $this->assertNotEmpty($metadataResult['c']);
+            $this->assertArrayHasKey('dt', $metadataResult);
+            $this->assertEquals('jsonb', $metadataResult['dt']);
             $this->assertArrayHasKey('sv', $metadataResult);
             $this->assertIsArray($metadataResult['sv']);
             $this->assertNotEmpty($metadataResult['sv']);


### PR DESCRIPTION
This change makes it so the `cast_as` value from the encryption configuration is returned as the `dt` parameter in all encryption responses. The data type parameter makes it so encrypted data can be type casted without requiring access to the original configuration. This will allow the [cipherstash/protectphp](https://github.com/cipherstash/protectphp) library to have automatic data type casting when decrypting data with this library, for example:

```php
$encrypted = Protect::encrypt(42, 'users.balance');
$decrypted = Protect::decrypt($encrypted);

echo $decrypted;
// 42
```

The `strum` crate was added for `CastAs` enum string serialization instead of relying on `serde` because it provides better performance for this use case. Rather than using `serde` to serialize the entire enum to JSON just to extract the string representation for a single parameter, `strum`'s dedicated `Display` derive macro allows direct string conversion with `snake_case` formatting while maintaining separate control over JSON serialization.