### PR TITLE
docs: update context-aware encryption and improve consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Configuration parameters:
 
 **Data Types**
 
-The `cast_as` field determines how plaintext data is processed before encryption:
+The `cast_as` parameter determines how plaintext data is processed before encryption:
 
 | Type | Description | Example Input |
 |------|-------------|---------------|
@@ -118,9 +118,9 @@ The `cast_as` field determines how plaintext data is processed before encryption
 
 **Index Types**
 
-The `indexes` field determines what operations are supported on encrypted data:
+The `indexes` parameter determines what operations are supported on encrypted data:
 
-| Index Type | Use Case | Response Field | Plaintext Queries | Search Terms Queries |
+| Index Type | Use Case | Response Parameter | Plaintext Queries | Search Terms Queries |
 |------------|----------|----------------|-------------------|---------------------|
 | `unique` | Exact equality queries and uniqueness constraints | `hm` | `eql_v2.hmac_256()` | `eql_v2.hmac_256()` |
 | `ore` | Equality, range comparisons, range queries, and ordering | `ob` | `eql_v2.ore_block_u64_8_256()` | `eql_v2.ore_block_u64_8_256()` |
@@ -129,7 +129,7 @@ The `indexes` field determines what operations are supported on encrypted data:
 
 **Unique Index (`unique`)**
 
-Enables exact equality queries and database uniqueness constraints. Uses the `hm` response field and works with the `eql_v2.hmac_256()` EQL function. This index generates HMAC-based hashes for exact equality matching.
+Enables exact equality queries and database uniqueness constraints. Uses the `hm` response parameter and works with the `eql_v2.hmac_256()` EQL function. This index generates HMAC-based hashes for exact equality matching.
 
 Basic usage:
 
@@ -185,7 +185,7 @@ WHERE eql_v2.hmac_256(email) = eql_v2.hmac_256(
 );
 ```
 
-For database-level uniqueness constraints, add a unique constraint on the `hm` response field:
+For database-level uniqueness constraints, add a unique constraint on the `hm` response parameter:
 
 ```sql
 CONSTRAINT unique_email UNIQUE ((email->>'hm'))
@@ -193,7 +193,7 @@ CONSTRAINT unique_email UNIQUE ((email->>'hm'))
 
 **Order Revealing Encryption Index (`ore`)**
 
-Enables equality, range operations, and ordering on encrypted data. Uses the `ob` response field and works with the `eql_v2.ore_block_u64_8_256()` EQL function. This index creates order-preserving encrypted values for equality checks, range comparisons, range queries, and sorting operations.
+Enables equality, range operations, and ordering on encrypted data. Uses the `ob` response parameter and works with the `eql_v2.ore_block_u64_8_256()` EQL function. This index creates order-preserving encrypted values for equality checks, range comparisons, range queries, and sorting operations.
 
 Basic usage:
 
@@ -265,7 +265,7 @@ ORDER BY eql_v2.ore_block_u64_8_256(systolic_bp) DESC;
 
 **Match Index (`match`)**
 
-Enables full-text search on encrypted text data using bloom filters. Uses the `bf` response field and works with the `eql_v2.bloom_filter()` EQL function. This index creates bloom filter representations of tokenized text for probabilistic matching.
+Enables full-text search on encrypted text data using bloom filters. Uses the `bf` response parameter and works with the `eql_v2.bloom_filter()` EQL function. This index creates bloom filter representations of tokenized text for probabilistic matching.
 
 Basic usage:
 
@@ -336,7 +336,7 @@ WHERE eql_v2.bloom_filter(medical_notes) @> eql_v2.bloom_filter(
 
 **Structured Text Encryption Vector Index (`ste_vec`)**
 
-Enables containment queries on encrypted JSONB data. Uses the `sv` response field and works with the `cs_ste_vec_v2()` EQL function for plaintext queries and PostgreSQL containment operators (`@>`, `<@`) for search terms queries. This index creates structured text encryption vectors that preserve JSON path relationships for encrypted JSONB containment matching.
+Enables containment queries on encrypted JSONB data. Uses the `sv` response parameter and works with the `cs_ste_vec_v2()` EQL function for plaintext queries and PostgreSQL containment operators (`@>`, `<@`) for search terms queries. This index creates structured text encryption vectors that preserve JSON path relationships for encrypted JSONB containment matching.
 
 Basic usage:
 
@@ -377,7 +377,7 @@ SELECT * FROM patient_records
 WHERE health_assessment <@ '{"sv":[{"s":"df08a4c4157bdb5bf6fa9be89cf18d10...","t":"22303063343133306135646334356130...","r":"mBbL}QHJ&a(@rwS5n)u^G+Fb+Ex8ofB!...","pa":false}],"i":{"t":"patient_records","c":"health_assessment"}}';
 ```
 
-This index differs from other indexes in its query patterns. Plaintext queries use `cs_ste_vec_v2()` with JSON data and only support the PostgreSQL `@>` operator, while search term queries can use both PostgreSQL `@>` and `<@` operators with pre-computed vectors from the `sv` response field in the search terms response.
+This index differs from other indexes in its query patterns. Plaintext queries use `cs_ste_vec_v2()` with JSON data and only support the PostgreSQL `@>` operator, while search term queries can use both PostgreSQL `@>` and `<@` operators with pre-computed vectors from the `sv` response parameter in the search terms response.
 
 ### Creating a Client
 

--- a/README.md
+++ b/README.md
@@ -460,16 +460,16 @@ $configJson = json_encode($config, JSON_THROW_ON_ERROR);
 $clientPtr = $client->newClient($configJson);
 
 try {
-    $resultJson = $client->encrypt(
+    $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
         columnName: 'email',
         tableName: 'patient_records',
     );
 
-    $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+    $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
-    $ciphertext = $result['c'];
+    $ciphertext = $encryptResult['c'];
 
     echo $ciphertext;
     // mBbKlk}G7QdaGiNj$dL7#+AOrA^}*VJx...
@@ -585,20 +585,20 @@ $configJson = json_encode($config, JSON_THROW_ON_ERROR);
 $clientPtr = $client->newClient($configJson);
 
 try {
-    $resultJson = $client->encrypt(
+    $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
         columnName: 'email',
         tableName: 'patient_records',
     );
 
-    $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+    $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
-    $ciphertext = $result['c'];
+    $ciphertext = $encryptResult['c'];
 
-    $plaintext = $client->decrypt($clientPtr, $ciphertext);
+    $decryptResult = $client->decrypt($clientPtr, $ciphertext);
 
-    echo $plaintext;
+    echo $decryptResult;
     // john@example.com
 } finally {
     $client->freeClient($clientPtr);
@@ -663,7 +663,7 @@ try {
 
     $contextJson = json_encode($context, JSON_THROW_ON_ERROR);
 
-    $resultJson = $client->encrypt(
+    $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
         columnName: 'email',
@@ -671,13 +671,13 @@ try {
         contextJson: $contextJson,
     );
 
-    $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+    $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
-    $ciphertext = $result['c'];
+    $ciphertext = $encryptResult['c'];
 
-    $plaintext = $client->decrypt($clientPtr, $ciphertext, $contextJson);
+    $decryptResult = $client->decrypt($clientPtr, $ciphertext, $contextJson);
 
-    echo $plaintext;
+    echo $decryptResult;
     // john@example.com
 } finally {
     $client->freeClient($clientPtr);
@@ -720,7 +720,7 @@ try {
 
     $contextJson = json_encode($context, JSON_THROW_ON_ERROR);
 
-    $resultJson = $client->encrypt(
+    $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
         columnName: 'email',
@@ -728,13 +728,13 @@ try {
         contextJson: $contextJson,
     );
 
-    $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+    $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
-    $ciphertext = $result['c'];
+    $ciphertext = $encryptResult['c'];
 
-    $plaintext = $client->decrypt($clientPtr, $ciphertext, $contextJson);
+    $decryptResult = $client->decrypt($clientPtr, $ciphertext, $contextJson);
 
-    echo $plaintext;
+    echo $decryptResult;
     // john@example.com
 } finally {
     $client->freeClient($clientPtr);
@@ -795,12 +795,12 @@ try {
     ];
 
     $itemsJson = json_encode($items, JSON_THROW_ON_ERROR);
-    $resultJson = $client->encryptBulk($clientPtr, $itemsJson);
+    $encryptResultJson = $client->encryptBulk($clientPtr, $itemsJson);
 
-    $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+    $encryptResults = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
-    foreach ($result as $encryptedData) {
-        $ciphertext = $encryptedData['c'];
+    foreach ($encryptResults as $encryptResult) {
+        $ciphertext = $encryptResult['c'];
 
         echo $ciphertext;
         // mBbKuXT|+vBh~K2WV-!n5_W3DBFd4`Mp...
@@ -926,7 +926,7 @@ $configJson = json_encode($config, JSON_THROW_ON_ERROR);
 $clientPtr = $client->newClient($configJson);
 
 try {
-    $terms = [
+    $searchTerms = [
         [
             'plaintext' => 'john@example.com',
             'column' => 'email',
@@ -942,11 +942,11 @@ try {
         ],
     ];
 
-    $termsJson = json_encode($terms, JSON_THROW_ON_ERROR);
-    $resultJson = $client->createSearchTerms($clientPtr, $termsJson);
-    $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+    $searchTermsJson = json_encode($searchTerms, JSON_THROW_ON_ERROR);
+    $searchTermsResultJson = $client->createSearchTerms($clientPtr, $searchTermsJson);
+    $searchTermsResult = json_decode(json: $searchTermsResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
-    foreach ($result as $searchTerms) {
+    foreach ($searchTermsResult as $searchTerms) {
         echo json_encode($searchTerms);
         // {"hm":"f3ca71fd39ae9d3d1d1fc25141bcb6da...","ob":null,"bf":null,"i":{"t":"patient_records","c":"email"}}
     }
@@ -1056,15 +1056,15 @@ try {
     $configJson = json_encode($config, JSON_THROW_ON_ERROR);
     $clientPtr = $client->newClient($configJson);
 
-    $resultJson = $client->encrypt(
+    $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
         columnName: 'email',
         tableName: 'patient_records',
     );
 
-    $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-    $ciphertext = $result['c'];
+    $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+    $ciphertext = $encryptResult['c'];
 
     echo $ciphertext;
     // mBbKlk}G7QdaGiNj$dL7#+AOrA^}*VJx...

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The `cast_as` parameter determines how plaintext data is processed before encryp
 | `text` | String data | `john@example.com` |
 | `boolean` | Boolean values | `true` or `false` |
 | `small_int` | 16-bit integer numbers | `32767` |
-| `int` | 32-bit integer numbers | `29` |
+| `int` | 32-bit integer numbers | `2147483647` |
 | `big_int` | 64-bit integer numbers | `9223372036854775807` |
 | `real` | Single-precision floating point | `25.99` |
 | `double` | Double-precision floating point | `3.141592653589793` |

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -96,28 +96,27 @@ class ClientTest extends TestCase
 
         try {
             $plaintext = 'john@example.com';
-            $resultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users');
+            $encryptResultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users');
 
-            $this->assertNotEquals($plaintext, $resultJson);
-
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($result);
-            $this->assertArrayHasKey('k', $result);
-            $this->assertEquals('ct', $result['k']);
-            $this->assertArrayHasKey('c', $result);
-            $this->assertIsString($result['c']);
-            $this->assertNotEmpty($result['c']);
-            $this->assertArrayHasKey('dt', $result);
-            $this->assertEquals('text', $result['dt']);
-            $this->assertArrayHasKey('i', $result);
-            $identifier = $result['i'];
+            $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($encryptResult);
+            $this->assertArrayHasKey('k', $encryptResult);
+            $this->assertEquals('ct', $encryptResult['k']);
+            $this->assertArrayHasKey('c', $encryptResult);
+            $ciphertext = $encryptResult['c'];
+            $this->assertIsString($ciphertext);
+            $this->assertNotEmpty($ciphertext);
+            $this->assertNotEquals($plaintext, $ciphertext);
+            $this->assertArrayHasKey('dt', $encryptResult);
+            $this->assertEquals('text', $encryptResult['dt']);
+            $this->assertArrayHasKey('i', $encryptResult);
+            $identifier = $encryptResult['i'];
             $this->assertIsArray($identifier);
             $this->assertEquals('users', $identifier['t']);
             $this->assertEquals('email', $identifier['c']);
 
-            $ciphertext = $result['c'];
-            $decrypted = $client->decrypt($clientPtr, $ciphertext);
-            $this->assertEquals($plaintext, $decrypted);
+            $decryptResult = $client->decrypt($clientPtr, $ciphertext);
+            $this->assertEquals($plaintext, $decryptResult);
         } finally {
             $client->freeClient($clientPtr);
         }
@@ -238,44 +237,43 @@ class ClientTest extends TestCase
                 ],
             ], JSON_THROW_ON_ERROR);
 
-            $resultJson = $client->encrypt($clientPtr, $complexJson, 'metadata', 'users');
+            $encryptResultJson = $client->encrypt($clientPtr, $complexJson, 'metadata', 'users');
 
-            $this->assertNotEquals($complexJson, $resultJson);
-
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($result);
-            $this->assertArrayHasKey('k', $result);
-            $this->assertEquals('sv', $result['k']);
-            $this->assertArrayHasKey('c', $result);
-            $this->assertIsString($result['c']);
-            $this->assertNotEmpty($result['c']);
-            $this->assertArrayHasKey('dt', $result);
-            $this->assertEquals('jsonb', $result['dt']);
-            $this->assertArrayHasKey('sv', $result);
-            $this->assertIsArray($result['sv']);
-            $this->assertNotEmpty($result['sv']);
-            $this->assertArrayHasKey('i', $result);
-            $identifier = $result['i'];
+            $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($encryptResult);
+            $this->assertArrayHasKey('k', $encryptResult);
+            $this->assertEquals('sv', $encryptResult['k']);
+            $this->assertArrayHasKey('c', $encryptResult);
+            $ciphertext = $encryptResult['c'];
+            $this->assertIsString($ciphertext);
+            $this->assertNotEmpty($ciphertext);
+            $this->assertNotEquals($complexJson, $ciphertext);
+            $this->assertArrayHasKey('dt', $encryptResult);
+            $this->assertEquals('jsonb', $encryptResult['dt']);
+            $this->assertArrayHasKey('sv', $encryptResult);
+            $this->assertIsArray($encryptResult['sv']);
+            $this->assertNotEmpty($encryptResult['sv']);
+            $this->assertArrayHasKey('i', $encryptResult);
+            $identifier = $encryptResult['i'];
             $this->assertIsArray($identifier);
             $this->assertEquals('users', $identifier['t']);
             $this->assertEquals('metadata', $identifier['c']);
 
-            $ciphertext = $result['c'];
-            $decrypted = $client->decrypt($clientPtr, $ciphertext);
+            $decryptResultJson = $client->decrypt($clientPtr, $ciphertext);
 
-            $decryptedData = json_decode(json: $decrypted, associative: true, flags: JSON_THROW_ON_ERROR);
+            $decryptResult = json_decode(json: $decryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
             $originalData = json_decode(json: $complexJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
-            $this->assertIsArray($decryptedData);
+            $this->assertIsArray($decryptResult);
             $this->assertIsArray($originalData);
 
-            $userProfile = $decryptedData['user_profile'];
+            $userProfile = $decryptResult['user_profile'];
             $this->assertIsArray($userProfile);
-            $billingInfo = $decryptedData['billing_info'];
+            $billingInfo = $decryptResult['billing_info'];
             $this->assertIsArray($billingInfo);
-            $activityData = $decryptedData['activity_data'];
+            $activityData = $decryptResult['activity_data'];
             $this->assertIsArray($activityData);
-            $systemMetadata = $decryptedData['system_metadata'];
+            $systemMetadata = $decryptResult['system_metadata'];
             $this->assertIsArray($systemMetadata);
 
             $this->assertEquals('CUST-20240315-7892', $userProfile['customer_id']);
@@ -413,21 +411,20 @@ class ClientTest extends TestCase
                 ],
             ], JSON_THROW_ON_ERROR);
 
-            $resultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users', $contextJson);
-            $this->assertNotEquals($plaintext, $resultJson);
+            $encryptResultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users', $contextJson);
+            $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($encryptResult);
+            $this->assertArrayHasKey('c', $encryptResult);
 
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($result);
-            $this->assertArrayHasKey('c', $result);
-
-            $ciphertext = $result['c'];
+            $ciphertext = $encryptResult['c'];
             $this->assertIsString($ciphertext);
             $this->assertNotEmpty($ciphertext);
-            $this->assertArrayHasKey('dt', $result);
-            $this->assertEquals('text', $result['dt']);
+            $this->assertNotEquals($plaintext, $ciphertext);
+            $this->assertArrayHasKey('dt', $encryptResult);
+            $this->assertEquals('text', $encryptResult['dt']);
 
-            $decrypted = $client->decrypt($clientPtr, $ciphertext, $contextJson);
-            $this->assertEquals($plaintext, $decrypted);
+            $decryptResult = $client->decrypt($clientPtr, $ciphertext, $contextJson);
+            $this->assertEquals($plaintext, $decryptResult);
         } finally {
             $client->freeClient($clientPtr);
         }
@@ -448,10 +445,10 @@ class ClientTest extends TestCase
                 ],
             ], JSON_THROW_ON_ERROR);
 
-            $resultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users', $originalContextJson);
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($result);
-            $ciphertext = $result['c'];
+            $encryptResultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users', $originalContextJson);
+            $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($encryptResult);
+            $ciphertext = $encryptResult['c'];
             $this->assertIsString($ciphertext);
 
             $wrongTagContextJson = json_encode([
@@ -483,10 +480,10 @@ class ClientTest extends TestCase
                 ],
             ], JSON_THROW_ON_ERROR);
 
-            $resultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users', $originalContextJson);
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($result);
-            $ciphertext = $result['c'];
+            $encryptResultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users', $originalContextJson);
+            $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($encryptResult);
+            $ciphertext = $encryptResult['c'];
             $this->assertIsString($ciphertext);
 
             $wrongValueContextJson = json_encode([
@@ -538,10 +535,10 @@ class ClientTest extends TestCase
             $plaintext = 'john@example.com';
             $contextJson = json_encode(['tag' => ['valid-context']], JSON_THROW_ON_ERROR);
 
-            $resultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users', $contextJson);
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($result);
-            $ciphertext = $result['c'];
+            $encryptResultJson = $client->encrypt($clientPtr, $plaintext, 'email', 'users', $contextJson);
+            $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($encryptResult);
+            $ciphertext = $encryptResult['c'];
             $this->assertIsString($ciphertext);
 
             $this->expectException(FFIException::class);
@@ -610,13 +607,13 @@ class ClientTest extends TestCase
             ];
 
             $itemsJson = json_encode($items, JSON_THROW_ON_ERROR);
-            $resultJson = $client->encryptBulk($clientPtr, $itemsJson);
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $encryptResultJson = $client->encryptBulk($clientPtr, $itemsJson);
+            $encryptResults = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
-            $this->assertIsArray($result);
-            $this->assertCount(4, $result);
+            $this->assertIsArray($encryptResults);
+            $this->assertCount(4, $encryptResults);
 
-            $emailResult = $result[0];
+            $emailResult = $encryptResults[0];
             $this->assertIsArray($emailResult);
             $this->assertArrayHasKey('k', $emailResult);
             $this->assertEquals('ct', $emailResult['k']);
@@ -631,7 +628,7 @@ class ClientTest extends TestCase
             $this->assertEquals('users', $emailIdentifier['t']);
             $this->assertEquals('email', $emailIdentifier['c']);
 
-            $ageResult = $result[1];
+            $ageResult = $encryptResults[1];
             $this->assertIsArray($ageResult);
             $this->assertArrayHasKey('k', $ageResult);
             $this->assertEquals('ct', $ageResult['k']);
@@ -646,7 +643,7 @@ class ClientTest extends TestCase
             $this->assertEquals('users', $ageIdentifier['t']);
             $this->assertEquals('age', $ageIdentifier['c']);
 
-            $jobTitleResult = $result[2];
+            $jobTitleResult = $encryptResults[2];
             $this->assertIsArray($jobTitleResult);
             $this->assertArrayHasKey('k', $jobTitleResult);
             $this->assertEquals('ct', $jobTitleResult['k']);
@@ -661,7 +658,7 @@ class ClientTest extends TestCase
             $this->assertEquals('users', $jobTitleIdentifier['t']);
             $this->assertEquals('job_title', $jobTitleIdentifier['c']);
 
-            $metadataResult = $result[3];
+            $metadataResult = $encryptResults[3];
             $this->assertIsArray($metadataResult);
             $this->assertArrayHasKey('k', $metadataResult);
             $this->assertEquals('sv', $metadataResult['k']);
@@ -695,7 +692,7 @@ class ClientTest extends TestCase
             $this->assertEquals('users', $metadataIdentifier['t']);
             $this->assertEquals('metadata', $metadataIdentifier['c']);
 
-            $ciphertexts = array_column($result, 'c');
+            $ciphertexts = array_column($encryptResults, 'c');
             $this->assertCount(4, $ciphertexts);
 
             foreach ($ciphertexts as $ciphertext) {
@@ -708,8 +705,8 @@ class ClientTest extends TestCase
             }, $ciphertexts);
 
             $encryptedItemsJson = json_encode($encryptedItems, JSON_THROW_ON_ERROR);
-            $decryptedResultJson = $client->decryptBulk($clientPtr, $encryptedItemsJson);
-            $decryptedPlaintexts = json_decode(json: $decryptedResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $decryptResultJson = $client->decryptBulk($clientPtr, $encryptedItemsJson);
+            $decryptResults = json_decode(json: $decryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
             $expectedPlaintexts = [
                 'john@example.com',
@@ -717,7 +714,8 @@ class ClientTest extends TestCase
                 'Software Engineer',
                 '{"city":"Boston","state":"MA"}',
             ];
-            $this->assertEquals($expectedPlaintexts, $decryptedPlaintexts);
+
+            $this->assertEquals($expectedPlaintexts, $decryptResults);
         } finally {
             $client->freeClient($clientPtr);
         }
@@ -827,7 +825,7 @@ class ClientTest extends TestCase
         $clientPtr = $client->newClient(self::$config);
 
         try {
-            $terms = [
+            $searchTerms = [
                 [
                     'plaintext' => 'john@example.com',
                     'column' => 'email',
@@ -850,44 +848,44 @@ class ClientTest extends TestCase
                 ],
             ];
 
-            $termsJson = json_encode($terms, JSON_THROW_ON_ERROR);
-            $resultJson = $client->createSearchTerms($clientPtr, $termsJson);
+            $searchTermsJson = json_encode($searchTerms, JSON_THROW_ON_ERROR);
+            $searchTermsResultJson = $client->createSearchTerms($clientPtr, $searchTermsJson);
 
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($result);
-            $this->assertCount(4, $result);
+            $searchTermsResult = json_decode(json: $searchTermsResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($searchTermsResult);
+            $this->assertCount(4, $searchTermsResult);
 
-            $emailTerm = $result[0];
+            $emailTerm = $searchTermsResult[0];
             $this->assertIsArray($emailTerm);
             $this->assertNotNull($emailTerm['hm']);
             $this->assertNull($emailTerm['ob']);
             $this->assertNotNull($emailTerm['bf']);
             $this->assertArrayHasKey('i', $emailTerm);
 
-            $ageTerm = $result[1];
+            $ageTerm = $searchTermsResult[1];
             $this->assertIsArray($ageTerm);
             $this->assertNull($ageTerm['hm']);
             $this->assertNotNull($ageTerm['ob']);
             $this->assertNull($ageTerm['bf']);
             $this->assertArrayHasKey('i', $ageTerm);
 
-            $jobTitleTerm = $result[2];
+            $jobTitleTerm = $searchTermsResult[2];
             $this->assertIsArray($jobTitleTerm);
             $this->assertNull($jobTitleTerm['hm']);
             $this->assertNull($jobTitleTerm['ob']);
             $this->assertNotNull($jobTitleTerm['bf']);
             $this->assertArrayHasKey('i', $jobTitleTerm);
 
-            $metadataTerm = $result[3];
+            $metadataTerm = $searchTermsResult[3];
             $this->assertIsArray($metadataTerm);
             $this->assertArrayHasKey('sv', $metadataTerm);
             $this->assertIsArray($metadataTerm['sv']);
             $this->assertNotEmpty($metadataTerm['sv']);
             $this->assertArrayHasKey('i', $metadataTerm);
 
-            foreach ($result as $searchTerm) {
-                $this->assertIsArray($searchTerm);
-                $identifier = $searchTerm['i'];
+            foreach ($searchTermsResult as $searchTerms) {
+                $this->assertIsArray($searchTerms);
+                $identifier = $searchTerms['i'];
                 $this->assertIsArray($identifier);
                 $this->assertEquals('users', $identifier['t']);
                 $this->assertContains($identifier['c'], ['email', 'age', 'job_title', 'metadata']);
@@ -903,7 +901,7 @@ class ClientTest extends TestCase
         $clientPtr = $client->newClient(self::$config);
 
         try {
-            $terms = [
+            $searchTerms = [
                 [
                     'plaintext' => 'john@example.com',
                     'column' => 'email',
@@ -912,14 +910,14 @@ class ClientTest extends TestCase
                 ],
             ];
 
-            $termsJson = json_encode($terms, JSON_THROW_ON_ERROR);
-            $resultJson = $client->createSearchTerms($clientPtr, $termsJson);
+            $searchTermsJson = json_encode($searchTerms, JSON_THROW_ON_ERROR);
+            $searchTermsResultJson = $client->createSearchTerms($clientPtr, $searchTermsJson);
 
-            $result = json_decode(json: $resultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($result);
-            $this->assertCount(1, $result);
+            $searchTermsResult = json_decode(json: $searchTermsResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($searchTermsResult);
+            $this->assertCount(1, $searchTermsResult);
 
-            $searchTerm = $result[0];
+            $searchTerm = $searchTermsResult[0];
             $this->assertIsArray($searchTerm);
             $this->assertNotNull($searchTerm['hm']);
             $this->assertNull($searchTerm['ob']);


### PR DESCRIPTION
This PR updates the documentation and testing to update context-aware encryption and improve consistency.

Adds a context type compatibility table to clarify which encryption contexts work with which index types, helping prevent configuration errors. Also documents that `ste_vec` indexes do not support encryption context to help avoid decryption failures. Updates bulk operation examples to show context usage patterns.

Standardizes variable names throughout README examples to be more descriptive and explicit to improve code clarity and maintain consistency across the codebase documentation.

Improves terminology consistency by standardizing configuration and response terminology, updating "field" references to "parameter" throughout the documentation for more precise language. Also updates the `int` data type example to use `2147483647` (32-bit max value) instead of `29` (follows the pattern from `small_int` and `big_int`).

Enhances testing by adding integration tests for encryption context functionality, including a test to verify that using encryption context with `ste_vec` indexes throws expected exceptions during decryption, documenting the known limitation. Adds bulk operations test with context to verify roundtrip encryption and decryption works correctly when context is provided for supported index types (`unique`, `ore`, `match`). Updates integration test variable names to match the improved conventions for consistency across the codebase.

These changes improve code clarity, maintains consistency across documentation and tests, and provides better guidance when working with encryption contexts.