### PR TITLE
fix(rust): ensure `SteVec` format always includes `sv` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Response parameters:
 | `k` | `string` | Always | Key type identifier (always `sv` for structured vector) |
 | `c` | `string` | Always | Base85-encoded ciphertext containing the encrypted data |
 | `dt` | `string` | Always | Data type for casting (from `cast_as` configuration parameter) |
-| `sv` | `array` | `ste_vec` | Structured text encryption vector for JSONB containment queries |
+| `sv` | `array\|null` | `ste_vec` | Structured text encryption vector for JSONB containment queries |
 | `sv[].s` | `string` | `ste_vec` | Tokenized selector representing the encrypted JSON path to the value |
 | `sv[].t` | `string` | `ste_vec` | Encrypted term value for equality and order-preserving queries |
 | `sv[].r` | `string` | `ste_vec` | Base85-encoded ciphertext containing the encrypted record data |
@@ -973,7 +973,7 @@ Response parameters:
 
 | Parameter | Type | Source | Description |
 |-----------|------|--------|-------------|
-| `sv` | `array` | `ste_vec` | Structured text encryption vector for JSONB containment queries |
+| `sv` | `array\|null` | `ste_vec` | Structured text encryption vector for JSONB containment queries |
 | `sv[].s` | `string` | `ste_vec` | Tokenized selector representing the encrypted JSON path to the value |
 | `sv[].t` | `string` | `ste_vec` | Encrypted term value for equality and order-preserving queries |
 | `sv[].r` | `string` | `ste_vec` | Base85-encoded ciphertext containing the encrypted record data |

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -45,6 +45,10 @@ class ClientTest extends TestCase
                             ],
                         ],
                     ],
+                    'session' => [
+                        'cast_as' => 'jsonb',
+                        'indexes' => (object) [],
+                    ],
                 ],
             ],
         ], JSON_THROW_ON_ERROR);
@@ -430,7 +434,7 @@ class ClientTest extends TestCase
         }
     }
 
-    public function test_decrypt_fails_with_wrong_tag_context(): void
+    public function test_decrypt_throws_exception_with_wrong_tag_context(): void
     {
         $client = new Client;
         $clientPtr = $client->newClient(self::$config);
@@ -465,7 +469,7 @@ class ClientTest extends TestCase
         }
     }
 
-    public function test_decrypt_fails_with_wrong_value_context(): void
+    public function test_decrypt_throws_exception_with_wrong_value_context(): void
     {
         $client = new Client;
         $clientPtr = $client->newClient(self::$config);
@@ -543,6 +547,25 @@ class ClientTest extends TestCase
 
             $this->expectException(FFIException::class);
             $client->decrypt($clientPtr, $ciphertext, 'invalid-context');
+        } finally {
+            $client->freeClient($clientPtr);
+        }
+    }
+
+    public function test_encrypt_jsonb_returns_null_sv_on_non_ste_vec_column(): void
+    {
+        $client = new Client;
+        $clientPtr = $client->newClient(self::$config);
+
+        try {
+            $sessionData = '{"browser": "Safari 17.4", "ip": "123.456.7.8", "last_active": "2020-01-21T10:30:00Z"}';
+
+            $encryptResultJson = $client->encrypt($clientPtr, $sessionData, 'session', 'users');
+            $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+
+            $this->assertSame('sv', $encryptResult['k']);
+            $this->assertSame('jsonb', $encryptResult['dt']);
+            $this->assertNull($encryptResult['sv']);
         } finally {
             $client->freeClient($clientPtr);
         }


### PR DESCRIPTION
Fix JSONB encryption to consistently return `SteVec` format with `sv` field present, even when no `SteVec` indexes are configured. Previously, JSONB columns without `SteVec` indexes would return `Ciphertext` format missing the expected `sv` field.

This ensures API consistency where JSONB always uses `SteVec` format regardless of index configuration, preventing clients from needing to handle different response formats for the same data type.