### PR TITLE
refactor(php): standardize parameter naming and method call formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,8 @@ try {
     $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
-        columnName: 'email',
-        tableName: 'users',
+        column: 'email',
+        table: 'users',
     );
 
     // {"k":"ct","c":"mBbKlk}G7QdaGiNj$dL7#+AOrA^}*VJx...","dt":"text","hm":"f3ca71fd39ae9d3d1d1fc25141bcb6da...","ob":null,"bf":[1124,2134,987,1456,743,2201],"i":{"t":"users","c":"email"},"v":2}
@@ -507,8 +507,8 @@ try {
     $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
-        columnName: 'email',
-        tableName: 'users',
+        column: 'email',
+        table: 'users',
     );
 
     $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
@@ -587,8 +587,8 @@ try {
     $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
-        columnName: 'email',
-        tableName: 'users',
+        column: 'email',
+        table: 'users',
         contextJson: $contextJson,
     );
 
@@ -646,8 +646,8 @@ try {
     $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
-        columnName: 'email',
-        tableName: 'users',
+        column: 'email',
+        table: 'users',
         contextJson: $contextJson,
     );
 
@@ -848,7 +848,7 @@ try {
     $configJson = json_encode($config, JSON_THROW_ON_ERROR);
     $clientPtr = $client->newClient($configJson);
 
-    $searchTerms = [
+    $items = [
         [
             'plaintext' => 'john@example.com',
             'column' => 'email',
@@ -864,8 +864,8 @@ try {
         ],
     ];
 
-    $searchTermsJson = json_encode($searchTerms, JSON_THROW_ON_ERROR);
-    $searchTermResultsJson = $client->createSearchTerms($clientPtr, $searchTermsJson);
+    $itemsJson = json_encode($items, JSON_THROW_ON_ERROR);
+    $searchTermResultsJson = $client->createSearchTerms($clientPtr, $itemsJson);
     // [{"hm":"f3ca71fd39ae9d3d1d1fc25141bcb6da...","ob":null,"bf":[1124,2134,987,1456,743,2201],"i":{"t":"users","c":"email"}},{"hm":"a8d5f2e9c4b7a1f3e8d2c5b9f6a3e7d1...","ob":["99f7adadadadadadc68b2822197a849e..."],"bf":null,"i":{"t":"users","c":"balance"}}]
 } finally {
     if ($clientPtr !== null) {
@@ -1054,8 +1054,8 @@ try {
     $encryptResultJson = $client->encrypt(
         client: $clientPtr,
         plaintext: 'john@example.com',
-        columnName: 'email',
-        tableName: 'users',
+        column: 'email',
+        table: 'users',
     );
 
     $encryptResult = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);

--- a/src/Client.php
+++ b/src/Client.php
@@ -67,18 +67,18 @@ class Client
      * Encrypt plaintext for a specific table column.
      *
      * @param  string|null  $contextJson  Encryption context as a JSON string
-     * @return string Encrypted data as a JSON string
+     * @return string Encrypted envelope as a JSON string
      *
      * @throws FFIException When encryption fails
      */
-    public function encrypt(\FFI\CData $client, string $plaintext, string $columnName, string $tableName, ?string $contextJson = null): string
+    public function encrypt(\FFI\CData $client, string $plaintext, string $column, string $table, ?string $contextJson = null): string
     {
-        $resultPtr = $this->executeFFIOperation(function (\FFI\CData $errorPtr) use ($client, $plaintext, $columnName, $tableName, $contextJson): ?\FFI\CData {
+        $resultPtr = $this->executeFFIOperation(function (\FFI\CData $errorPtr) use ($client, $plaintext, $column, $table, $contextJson): ?\FFI\CData {
             $result = $this->ffi->encrypt(
                 $client,
                 $plaintext,
-                $columnName,
-                $tableName,
+                $column,
+                $table,
                 $contextJson,
                 \FFI::addr($errorPtr)
             );
@@ -125,18 +125,14 @@ class Client
      * Encrypt multiple values in a single batch operation.
      *
      * @param  string  $itemsJson  Items to encrypt as a JSON string
-     * @return string Array of encrypted objects as a JSON string
+     * @return string Encrypted envelopes as a JSON string
      *
      * @throws FFIException When encryption fails
      */
     public function encryptBulk(\FFI\CData $client, string $itemsJson): string
     {
         $resultPtr = $this->executeFFIOperation(function (\FFI\CData $errorPtr) use ($client, $itemsJson): ?\FFI\CData {
-            $result = $this->ffi->encrypt_bulk(
-                $client,
-                $itemsJson,
-                \FFI::addr($errorPtr)
-            );
+            $result = $this->ffi->encrypt_bulk($client, $itemsJson, \FFI::addr($errorPtr));
 
             return $result instanceof \FFI\CData ? $result : null;
         }, FFIException::failedToBulkEncrypt(...));
@@ -152,18 +148,14 @@ class Client
      * Decrypt multiple ciphertext values in a single batch operation.
      *
      * @param  string  $itemsJson  Items to decrypt as a JSON string
-     * @return string Array of decrypted plaintext strings as a JSON string
+     * @return string Decrypted plaintext strings as a JSON string
      *
      * @throws FFIException When decryption fails
      */
     public function decryptBulk(\FFI\CData $client, string $itemsJson): string
     {
         $resultPtr = $this->executeFFIOperation(function (\FFI\CData $errorPtr) use ($client, $itemsJson): ?\FFI\CData {
-            $result = $this->ffi->decrypt_bulk(
-                $client,
-                $itemsJson,
-                \FFI::addr($errorPtr)
-            );
+            $result = $this->ffi->decrypt_bulk($client, $itemsJson, \FFI::addr($errorPtr));
 
             return $result instanceof \FFI\CData ? $result : null;
         }, FFIException::failedToBulkDecrypt(...));
@@ -176,21 +168,17 @@ class Client
     }
 
     /**
-     * Create encrypted search terms for querying encrypted data.
+     * Create search terms for querying encrypted data.
      *
-     * @param  string  $termsJson  Search terms as a JSON string
-     * @return string Array of encrypted search terms as a JSON string
+     * @param  string  $itemsJson  Items to create search terms for as a JSON string
+     * @return string Search terms as a JSON string
      *
      * @throws FFIException When search term creation fails
      */
-    public function createSearchTerms(\FFI\CData $client, string $termsJson): string
+    public function createSearchTerms(\FFI\CData $client, string $itemsJson): string
     {
-        $resultPtr = $this->executeFFIOperation(function (\FFI\CData $errorPtr) use ($client, $termsJson): ?\FFI\CData {
-            $result = $this->ffi->create_search_terms(
-                $client,
-                $termsJson,
-                \FFI::addr($errorPtr)
-            );
+        $resultPtr = $this->executeFFIOperation(function (\FFI\CData $errorPtr) use ($client, $itemsJson): ?\FFI\CData {
+            $result = $this->ffi->create_search_terms($client, $itemsJson, \FFI::addr($errorPtr));
 
             return $result instanceof \FFI\CData ? $result : null;
         }, FFIException::failedToCreateSearchTerms(...));

--- a/tests/Integration/ClientTest.php
+++ b/tests/Integration/ClientTest.php
@@ -631,8 +631,8 @@ class ClientTest extends TestCase
             ];
 
             $itemsJson = json_encode($items, JSON_THROW_ON_ERROR);
-            $encryptResultJson = $client->encryptBulk($clientPtr, $itemsJson);
-            $encryptResults = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $encryptResultsJson = $client->encryptBulk($clientPtr, $itemsJson);
+            $encryptResults = json_decode(json: $encryptResultsJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
             $this->assertIsArray($encryptResults);
             $this->assertCount(4, $encryptResults);
@@ -729,8 +729,8 @@ class ClientTest extends TestCase
             }, $ciphertexts);
 
             $encryptedItemsJson = json_encode($encryptedItems, JSON_THROW_ON_ERROR);
-            $decryptResultJson = $client->decryptBulk($clientPtr, $encryptedItemsJson);
-            $decryptResults = json_decode(json: $decryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $decryptResultsJson = $client->decryptBulk($clientPtr, $encryptedItemsJson);
+            $decryptResults = json_decode(json: $decryptResultsJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
             $expectedPlaintexts = [
                 'john@example.com',
@@ -778,8 +778,8 @@ class ClientTest extends TestCase
             ];
 
             $itemsJson = json_encode($items, JSON_THROW_ON_ERROR);
-            $encryptResultJson = $client->encryptBulk($clientPtr, $itemsJson);
-            $encryptResults = json_decode(json: $encryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $encryptResultsJson = $client->encryptBulk($clientPtr, $itemsJson);
+            $encryptResults = json_decode(json: $encryptResultsJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
             $this->assertIsArray($encryptResults);
             $this->assertCount(4, $encryptResults);
@@ -801,8 +801,8 @@ class ClientTest extends TestCase
             }, $items, $encryptResults);
 
             $decryptItemsJson = json_encode($decryptItems, JSON_THROW_ON_ERROR);
-            $decryptResultJson = $client->decryptBulk($clientPtr, $decryptItemsJson);
-            $decryptResults = json_decode(json: $decryptResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $decryptResultsJson = $client->decryptBulk($clientPtr, $decryptItemsJson);
+            $decryptResults = json_decode(json: $decryptResultsJson, associative: true, flags: JSON_THROW_ON_ERROR);
 
             $expectedPlaintexts = [
                 'john@example.com',
@@ -849,7 +849,7 @@ class ClientTest extends TestCase
         $clientPtr = $client->newClient(self::$config);
 
         try {
-            $searchTerms = [
+            $items = [
                 [
                     'plaintext' => 'john@example.com',
                     'column' => 'email',
@@ -872,44 +872,44 @@ class ClientTest extends TestCase
                 ],
             ];
 
-            $searchTermsJson = json_encode($searchTerms, JSON_THROW_ON_ERROR);
-            $searchTermsResultJson = $client->createSearchTerms($clientPtr, $searchTermsJson);
+            $itemsJson = json_encode($items, JSON_THROW_ON_ERROR);
+            $searchTermResultsJson = $client->createSearchTerms($clientPtr, $itemsJson);
 
-            $searchTermsResult = json_decode(json: $searchTermsResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($searchTermsResult);
-            $this->assertCount(4, $searchTermsResult);
+            $searchTermResults = json_decode(json: $searchTermResultsJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($searchTermResults);
+            $this->assertCount(4, $searchTermResults);
 
-            $emailTerm = $searchTermsResult[0];
+            $emailTerm = $searchTermResults[0];
             $this->assertIsArray($emailTerm);
             $this->assertNotNull($emailTerm['hm']);
             $this->assertNull($emailTerm['ob']);
             $this->assertNotNull($emailTerm['bf']);
             $this->assertArrayHasKey('i', $emailTerm);
 
-            $ageTerm = $searchTermsResult[1];
+            $ageTerm = $searchTermResults[1];
             $this->assertIsArray($ageTerm);
             $this->assertNull($ageTerm['hm']);
             $this->assertNotNull($ageTerm['ob']);
             $this->assertNull($ageTerm['bf']);
             $this->assertArrayHasKey('i', $ageTerm);
 
-            $jobTitleTerm = $searchTermsResult[2];
+            $jobTitleTerm = $searchTermResults[2];
             $this->assertIsArray($jobTitleTerm);
             $this->assertNull($jobTitleTerm['hm']);
             $this->assertNull($jobTitleTerm['ob']);
             $this->assertNotNull($jobTitleTerm['bf']);
             $this->assertArrayHasKey('i', $jobTitleTerm);
 
-            $metadataTerm = $searchTermsResult[3];
+            $metadataTerm = $searchTermResults[3];
             $this->assertIsArray($metadataTerm);
             $this->assertArrayHasKey('sv', $metadataTerm);
             $this->assertIsArray($metadataTerm['sv']);
             $this->assertNotEmpty($metadataTerm['sv']);
             $this->assertArrayHasKey('i', $metadataTerm);
 
-            foreach ($searchTermsResult as $searchTerms) {
-                $this->assertIsArray($searchTerms);
-                $identifier = $searchTerms['i'];
+            foreach ($searchTermResults as $searchTerm) {
+                $this->assertIsArray($searchTerm);
+                $identifier = $searchTerm['i'];
                 $this->assertIsArray($identifier);
                 $this->assertSame('users', $identifier['t']);
                 $this->assertContains($identifier['c'], ['email', 'age', 'job_title', 'metadata']);
@@ -925,7 +925,7 @@ class ClientTest extends TestCase
         $clientPtr = $client->newClient(self::$config);
 
         try {
-            $searchTerms = [
+            $items = [
                 [
                     'plaintext' => 'john@example.com',
                     'column' => 'email',
@@ -934,14 +934,14 @@ class ClientTest extends TestCase
                 ],
             ];
 
-            $searchTermsJson = json_encode($searchTerms, JSON_THROW_ON_ERROR);
-            $searchTermsResultJson = $client->createSearchTerms($clientPtr, $searchTermsJson);
+            $itemsJson = json_encode($items, JSON_THROW_ON_ERROR);
+            $searchTermResultsJson = $client->createSearchTerms($clientPtr, $itemsJson);
 
-            $searchTermsResult = json_decode(json: $searchTermsResultJson, associative: true, flags: JSON_THROW_ON_ERROR);
-            $this->assertIsArray($searchTermsResult);
-            $this->assertCount(1, $searchTermsResult);
+            $searchTermResults = json_decode(json: $searchTermResultsJson, associative: true, flags: JSON_THROW_ON_ERROR);
+            $this->assertIsArray($searchTermResults);
+            $this->assertCount(1, $searchTermResults);
 
-            $searchTerm = $searchTermsResult[0];
+            $searchTerm = $searchTermResults[0];
             $this->assertIsArray($searchTerm);
             $this->assertNotNull($searchTerm['hm']);
             $this->assertNull($searchTerm['ob']);


### PR DESCRIPTION
Following PR #19, after building the initial version of [cipherstash/protectphp](https://github.com/cipherstash/protectphp), here are a few improvements I found that could benefit the PHP methods.